### PR TITLE
add: Added a new field to orders that allows the user to enter a promotion_code upon creating an order.

### DIFF
--- a/api/controllers/orders.py
+++ b/api/controllers/orders.py
@@ -13,7 +13,8 @@ def create(db: Session, request):
         amount=request.amount,
         restaurant_id=request.restaurant_id,
         delivery_method=request.delivery_method,
-        status_of_order=request.status_of_order
+        status_of_order=request.status_of_order,
+        promotion_code=request.promotion_code
     )
 
     try:

--- a/api/models/orders.py
+++ b/api/models/orders.py
@@ -16,6 +16,7 @@ class Order(Base):
     restaurant_id = Column(Integer, ForeignKey("restaurants.id"), nullable=False)
     delivery_method = Column(String(300), nullable=False)
     status_of_order = Column(String(300), nullable=False, server_default="pending")
+    promotion_code = Column(String(300), nullable=True, server_default="N/A")
 
     sandwich = relationship("Sandwich", back_populates="orders")
     restaurant = relationship("Restaurant", back_populates="orders")

--- a/api/schemas/orders.py
+++ b/api/schemas/orders.py
@@ -16,6 +16,7 @@ class OrderBase(BaseModel):
     restaurant_id: int
     delivery_method: str
     status_of_order: str
+    promotion_code: str
 
 
 class OrderCreate(OrderBase):
@@ -31,6 +32,7 @@ class OrderUpdate(BaseModel):
     amount: Optional[float]
     restaurant_id: Optional[int]
     delivery_method: Optional[str]
+    promotion_code: Optional[str]
 
 
 class Order(OrderBase):
@@ -43,6 +45,7 @@ class Order(OrderBase):
     amount: float
     restaurant_id: int
     delivery_method: Optional[str]
+    promotion_code: Optional[str]
 
 
     class ConfigDict:


### PR DESCRIPTION
Added promotion_code field to orders schema and tables that allows a user to enter a promotion code upon creating an order. The default value is N/A for non-applicable if they do not have a promotion code 