### PR TITLE
fix: fixed foreign key to match the string of the promo code and not the int | updated sql file to reflect | added foreign key relationship to promo_code in coupons table.

### DIFF
--- a/api/models/orders.py
+++ b/api/models/orders.py
@@ -16,7 +16,7 @@ class Order(Base):
     restaurant_id = Column(Integer, ForeignKey("restaurants.id"), nullable=False)
     delivery_method = Column(String(300), nullable=False)
     status_of_order = Column(String(300), nullable=False, server_default="pending")
-    promotion_code = Column(String(300), ForeignKey("coupons.id"), nullable=True, server_default="N/A")
+    promo_code = Column(String(500), ForeignKey("coupons.promo_code"), nullable=True, server_default="N/A")
 
     sandwich = relationship("Sandwich", back_populates="orders")
     restaurant = relationship("Restaurant", back_populates="orders")

--- a/api/models/orders.py
+++ b/api/models/orders.py
@@ -16,9 +16,10 @@ class Order(Base):
     restaurant_id = Column(Integer, ForeignKey("restaurants.id"), nullable=False)
     delivery_method = Column(String(300), nullable=False)
     status_of_order = Column(String(300), nullable=False, server_default="pending")
-    promotion_code = Column(String(300), nullable=True, server_default="N/A")
+    promotion_code = Column(String(300), ForeignKey("coupons.id"), nullable=True, server_default="N/A")
 
     sandwich = relationship("Sandwich", back_populates="orders")
     restaurant = relationship("Restaurant", back_populates="orders")
     user = relationship("User", back_populates="orders")
-    reviews = relationship("Review", back_populates="order")
+    reviews = relationship("Review", back_populates="orders")
+    coupons = relationship("Coupon", back_populates="orders")

--- a/api/schemas/orders.py
+++ b/api/schemas/orders.py
@@ -16,7 +16,7 @@ class OrderBase(BaseModel):
     restaurant_id: int
     delivery_method: str
     status_of_order: str
-    promotion_code: str
+    promo_code: str
 
 
 class OrderCreate(OrderBase):
@@ -32,7 +32,7 @@ class OrderUpdate(BaseModel):
     amount: Optional[float]
     restaurant_id: Optional[int]
     delivery_method: Optional[str]
-    promotion_code: Optional[str]
+    promo_code: Optional[str]
 
 
 class Order(OrderBase):
@@ -45,7 +45,7 @@ class Order(OrderBase):
     amount: float
     restaurant_id: int
     delivery_method: Optional[str]
-    promotion_code: Optional[str]
+    promo_code: Optional[str]
 
 
     class ConfigDict:

--- a/schema.sql
+++ b/schema.sql
@@ -30,10 +30,10 @@ VALUES
 (3, 'BOGO50', 0, 50.0, '2024-12-31 23:59:59', 3);
 
 
-INSERT INTO orders (id, user_id, order_date, description, sandwich_id, amount, restaurant_id, delivery_method, status_of_order) VALUES
-(1, 1, '2024-01-01 12:00:00', 'Order 1 description', 1, 2, 1, 'Delivery', 'pending'),
-(2, 2, '2024-01-02 13:00:00', 'Order 2 description', 2, 1, 2, 'Pickup', 'completed'),
-(3, 3, '2024-01-03 14:00:00', 'Order 3 description', 3, 3, 3, 'Delivery', 'canceled');
+INSERT INTO orders (id, user_id, order_date, description, sandwich_id, amount, restaurant_id, delivery_method, status_of_order, promo_code) VALUES
+(1, 1, '2024-01-01 12:00:00', 'Order 1 description', 1, 2, 1, 'Delivery', 'pending', 'DISCOUNT10'),
+(2, 2, '2024-01-02 13:00:00', 'Order 2 description', 2, 1, 2, 'Pickup', 'completed', ''),
+(3, 3, '2024-01-03 14:00:00', 'Order 3 description', 3, 3, 3, 'Delivery', 'canceled', 'BOGO50');
 
 INSERT INTO reviews (id, order_id, restaurant_id, user_id, rating, description) VALUES
 (1, 1, 1, 1, 5, 'Great food!'),

--- a/schema.sql
+++ b/schema.sql
@@ -32,7 +32,7 @@ VALUES
 
 INSERT INTO orders (id, user_id, order_date, description, sandwich_id, amount, restaurant_id, delivery_method, status_of_order, promo_code) VALUES
 (1, 1, '2024-01-01 12:00:00', 'Order 1 description', 1, 2, 1, 'Delivery', 'pending', 'DISCOUNT10'),
-(2, 2, '2024-01-02 13:00:00', 'Order 2 description', 2, 1, 2, 'Pickup', 'completed', ''),
+(2, 2, '2024-01-02 13:00:00', 'Order 2 description', 2, 1, 2, 'Pickup', 'completed', null),
 (3, 3, '2024-01-03 14:00:00', 'Order 3 description', 3, 3, 3, 'Delivery', 'canceled', 'BOGO50');
 
 INSERT INTO reviews (id, order_id, restaurant_id, user_id, rating, description) VALUES


### PR DESCRIPTION
Orders: 
![image](https://github.com/user-attachments/assets/6f6656e6-b4c1-4be8-8867-6a11b770281e)

Coupons:
![image](https://github.com/user-attachments/assets/a87b3653-a0e1-4ba2-9f70-f3ed358058e7)
